### PR TITLE
Migrate from master and slave vocabulary

### DIFF
--- a/OpenSource_Python_Code/Cython-0.20/Cython/Compiler/Nodes.py
+++ b/OpenSource_Python_Code/Cython-0.20/Cython/Compiler/Nodes.py
@@ -7539,7 +7539,7 @@ class ParallelStatNode(StatNode, ParallelNode):
         """
         As each OpenMP thread may raise an exception, we need to fetch that
         exception from the threadstate and save it for after the parallel
-        section where it can be re-raised in the master thread.
+        section where it can be re-raised in the main thread.
 
         Although it would seem that __pyx_filename, __pyx_lineno and
         __pyx_clineno are only assigned to under exception conditions (i.e.,

--- a/OpenSource_Python_Code/Cython-0.20/build/lib.macosx-10.6-intel-2.7/Cython/Compiler/Nodes.py
+++ b/OpenSource_Python_Code/Cython-0.20/build/lib.macosx-10.6-intel-2.7/Cython/Compiler/Nodes.py
@@ -7539,7 +7539,7 @@ class ParallelStatNode(StatNode, ParallelNode):
         """
         As each OpenMP thread may raise an exception, we need to fetch that
         exception from the threadstate and save it for after the parallel
-        section where it can be re-raised in the master thread.
+        section where it can be re-raised in the main thread.
 
         Although it would seem that __pyx_filename, __pyx_lineno and
         __pyx_clineno are only assigned to under exception conditions (i.e.,

--- a/OpenSource_Python_Code/Cython-0.20/docs/conf.py
+++ b/OpenSource_Python_Code/Cython-0.20/docs/conf.py
@@ -58,8 +58,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 exclude_patterns = ['py*', 'build']
 

--- a/OpenSource_Python_Code/buildozer-master/buildozer/targets/android.py
+++ b/OpenSource_Python_Code/buildozer-master/buildozer/targets/android.py
@@ -305,7 +305,7 @@ class TargetAndroid(Target):
                     cwd=self.buildozer.platform_dir)
         elif self.platform_update:
             cmd('git clean -dxf', cwd=pa_dir)
-            cmd('git pull origin master', cwd=pa_dir)
+            cmd('git pull origin main', cwd=pa_dir)
 
         source = self.buildozer.config.getdefault('app', 'android.branch')
         if source:

--- a/OpenSource_Python_Code/buildozer-master/buildozer/targets/ios.py
+++ b/OpenSource_Python_Code/buildozer-master/buildozer/targets/ios.py
@@ -95,7 +95,7 @@ class TargetIos(Target):
                     cwd=self.buildozer.platform_dir)
         elif self.platform_update:
             cmd('git clean -dxf', cwd=ios_dir)
-            cmd('git pull origin master', cwd=ios_dir)
+            cmd('git pull origin main', cwd=ios_dir)
 
         self.fruitstrap_dir = fruitstrap_dir = join(self.buildozer.platform_dir,
                 'fruitstrap')

--- a/OpenSource_Python_Code/epydoc-master/src/build/lib/epydoc/gui.py
+++ b/OpenSource_Python_Code/epydoc-master/src/build/lib/epydoc/gui.py
@@ -403,8 +403,8 @@ class EpydocGUI:
         self._canvas.bind('<Configure>', self._configure)
 
     def _init_messages(self, msgsframe, ctrlframe):
-        self._downImage = PhotoImage(master=self._root, data=DOWN_GIF)
-        self._upImage = PhotoImage(master=self._root, data=UP_GIF)
+        self._downImage = PhotoImage(main=self._root, data=DOWN_GIF)
+        self._upImage = PhotoImage(main=self._root, data=UP_GIF)
 
         # Set up the messages control frame
         b1 = Button(ctrlframe, text="Messages", justify='center',
@@ -476,8 +476,8 @@ class EpydocGUI:
         self._messages.tag_config('header', elide=elide_headers)
 
     def _init_options(self, optsframe, ctrlframe):
-        self._leftImage=PhotoImage(master=self._root, data=LEFT_GIF)
-        self._rightImage=PhotoImage(master=self._root, data=RIGHT_GIF)
+        self._leftImage=PhotoImage(main=self._root, data=LEFT_GIF)
+        self._rightImage=PhotoImage(main=self._root, data=RIGHT_GIF)
 
         # Set up the options control frame
         b1 = Button(ctrlframe, text="Options", justify='center',

--- a/OpenSource_Python_Code/epydoc-master/src/epydoc/gui.py
+++ b/OpenSource_Python_Code/epydoc-master/src/epydoc/gui.py
@@ -403,8 +403,8 @@ class EpydocGUI:
         self._canvas.bind('<Configure>', self._configure)
 
     def _init_messages(self, msgsframe, ctrlframe):
-        self._downImage = PhotoImage(master=self._root, data=DOWN_GIF)
-        self._upImage = PhotoImage(master=self._root, data=UP_GIF)
+        self._downImage = PhotoImage(main=self._root, data=DOWN_GIF)
+        self._upImage = PhotoImage(main=self._root, data=UP_GIF)
 
         # Set up the messages control frame
         b1 = Button(ctrlframe, text="Messages", justify='center',
@@ -476,8 +476,8 @@ class EpydocGUI:
         self._messages.tag_config('header', elide=elide_headers)
 
     def _init_options(self, optsframe, ctrlframe):
-        self._leftImage=PhotoImage(master=self._root, data=LEFT_GIF)
-        self._rightImage=PhotoImage(master=self._root, data=RIGHT_GIF)
+        self._leftImage=PhotoImage(main=self._root, data=LEFT_GIF)
+        self._rightImage=PhotoImage(main=self._root, data=RIGHT_GIF)
 
         # Set up the options control frame
         b1 = Button(ctrlframe, text="Options", justify='center',

--- a/OpenSource_Python_Code/horizon-2013.1/doc/source/conf.py
+++ b/OpenSource_Python_Code/horizon-2013.1/doc/source/conf.py
@@ -159,8 +159,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'Horizon'

--- a/OpenSource_Python_Code/horizon-master/doc/source/conf.py
+++ b/OpenSource_Python_Code/horizon-master/doc/source/conf.py
@@ -156,8 +156,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'Horizon'

--- a/OpenSource_Python_Code/mlpy-3.5.0/docs/source/conf.py
+++ b/OpenSource_Python_Code/mlpy-3.5.0/docs/source/conf.py
@@ -36,8 +36,8 @@ source_suffix = '.txt'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'mlpy'


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.